### PR TITLE
Fix react not defined blog error

### DIFF
--- a/src/components/BlogAdmin.tsx
+++ b/src/components/BlogAdmin.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { supabase } from "../lib/supabase";
 import { useRouter } from "next/navigation";
 

--- a/src/components/BlogModule.tsx
+++ b/src/components/BlogModule.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { supabase } from "../lib/supabase";
 import MarkdownIt from "markdown-it";
 import { UserAuth } from "./UserAuth";

--- a/src/components/UserAuth.tsx
+++ b/src/components/UserAuth.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { supabase } from "../lib/supabase";
 
 interface UserAuthProps {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,7 +8,8 @@
     "incremental": false,
     "outDir": "dist",
     "module": "esnext",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "jsx": "react-jsx"
   },
   "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -16,4 +16,13 @@ export default defineConfig({
   splitting: false,
   minify: false,
   tsconfig: 'tsconfig.build.json',
+  // Ensure React is not bundled and JSX uses automatic runtime
+  external: ['react', 'react-dom', 'next'],
+  esbuildOptions(options) {
+    options.jsx = 'automatic';
+    options.jsxImportSource = 'react';
+  },
+  banner: {
+    js: '"use client";'
+  }
 });


### PR DESCRIPTION
Configure build to use React's automatic JSX runtime and externalize React to fix `ReferenceError: React is not defined`.

The package's previous build configuration emitted JSX that expected a global `React` object (classic runtime) or bundled React, causing a `ReferenceError` when integrated into a Next.js application that uses the automatic JSX runtime and expects React to be a peer dependency. This change ensures the package's output is compatible.

---
<a href="https://cursor.com/background-agent?bcId=bc-63a83d00-32ca-4d39-b00d-d81737d03a8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63a83d00-32ca-4d39-b00d-d81737d03a8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

